### PR TITLE
Add support for apns-collapse-id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Backup[ ]of[ ]*.key/
 Backup[ ]of[ ]*.numbers/
 
 Pods/
+/.ruby-version

--- a/Knuff/APNSViewController.m
+++ b/Knuff/APNSViewController.m
@@ -44,6 +44,8 @@
 @property (weak) IBOutlet NSTextField *tokenTextField;
 @property (weak) IBOutlet NSButton *devicesButton;
 
+@property (weak) IBOutlet NSTextField *collapseIdTextField;
+
 @property (nonatomic, strong, readonly) NSDictionary *payload;
 
 @property (weak) IBOutlet MGSFragariaView *fragariaView;
@@ -192,6 +194,7 @@
                    toToken:[self preparedToken]
                  withTopic:topics.firstObject
                   priority:self.document.priority
+                collapseId:[self preparedCollapseId]
                  inSandbox:sandbox];
   } else if ([self document].mode == APNSItemModeKnuff) {
     // Grab cert
@@ -564,6 +567,17 @@
   NSCharacterSet *removeCharacterSet = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
   token = [[token componentsSeparatedByCharactersInSet:removeCharacterSet] componentsJoinedByString:@""];
   return [token lowercaseString];
+}
+
+#pragma mark -
+
+- (nullable NSString *)preparedCollapseId {
+    NSString *collapseId = self.collapseIdTextField.stringValue;
+    if (collapseId.length == 0) {
+        return nil;
+    } else {
+        return collapseId;
+    }
 }
 
 #pragma mark -

--- a/Knuff/Base.lproj/Main.storyboard
+++ b/Knuff/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15A279b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
         <capability name="box content view" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
@@ -823,6 +823,27 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="hAz-10-i53">
+                                        <rect key="frame" x="150" y="213" width="81" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Collapse Id:" id="imc-hw-x1H">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField verticalHuggingPriority="750" id="52p-Ki-O92">
+                                        <rect key="frame" x="228" y="210" width="145" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="PPu-S1-8jR">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                        <connections>
+                                            <outlet property="delegate" destination="5gI-5U-AMq" id="q2j-Yh-dH1"/>
+                                        </connections>
+                                    </textField>
                                 </subviews>
                             </customView>
                             <segmentedControl verticalHuggingPriority="750" springLoaded="YES" id="oPK-43-5bT">
@@ -842,6 +863,7 @@
                         </subviews>
                     </view>
                     <connections>
+                        <outlet property="collapseIdTextField" destination="52p-Ki-O92" id="Q0s-Ld-PiV"/>
                         <outlet property="devicesButton" destination="vRS-dS-ngr" id="8DS-RM-9JB"/>
                         <outlet property="fragariaView" destination="Lwi-gz-XGt" id="cfr-wK-DYu"/>
                         <outlet property="identityView" destination="qIH-Kw-NVg" id="rFM-Gk-hIi"/>

--- a/Knuff/SBAPNS.h
+++ b/Knuff/SBAPNS.h
@@ -22,5 +22,12 @@
             toToken:(nonnull NSString *)token
           withTopic:(nullable NSString *)topic
            priority:(NSUInteger)priority
+         collapseId:(nullable NSString *)collapseId
+          inSandbox:(BOOL)sandbox;
+
+- (void)pushPayload:(nonnull NSDictionary *)payload
+            toToken:(nonnull NSString *)token
+          withTopic:(nullable NSString *)topic
+           priority:(NSUInteger)priority
           inSandbox:(BOOL)sandbox;
 @end

--- a/Knuff/SBAPNS.m
+++ b/Knuff/SBAPNS.m
@@ -45,40 +45,56 @@
             toToken:(nonnull NSString *)token
           withTopic:(nullable NSString *)topic
            priority:(NSUInteger)priority
+         collapseId:(nullable NSString *)collapseId
           inSandbox:(BOOL)sandbox {
-  
-  
-  NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://api%@.push.apple.com/3/device/%@", sandbox?@".development":@"", token]]];
-  request.HTTPMethod = @"POST";
-  
-  request.HTTPBody = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
-  
-  if (topic) {
-    [request addValue:topic forHTTPHeaderField:@"apns-topic"];
-  }
-  
-  [request addValue:[NSString stringWithFormat:@"%lu", (unsigned long)priority] forHTTPHeaderField:@"apns-priority"];
-  
-  // apns-expiration
-  // apns-id
-  
-  NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-    NSHTTPURLResponse *r = (NSHTTPURLResponse *)response;
-
-    if (r.statusCode != 200 && data) {
-      NSError *error;
-      NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-      
-      if (error) {return;}
-      
-      NSString *reason = dict[@"reason"];
-      
-      // Not implemented?
-//      NSString *ID = r.allHeaderFields[@"apns-id"];
-      [self.delegate APNS:self didRecieveStatus:r.statusCode reason:reason forID:nil];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://api%@.push.apple.com/3/device/%@", sandbox?@".development":@"", token]]];
+    request.HTTPMethod = @"POST";
+    
+    request.HTTPBody = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+    
+    if (topic) {
+        [request addValue:topic forHTTPHeaderField:@"apns-topic"];
     }
-  }];
-  [task resume];
+    
+    if (collapseId) {
+        [request addValue:collapseId forHTTPHeaderField:@"apns-collapse-id"];
+    }
+    
+    [request addValue:[NSString stringWithFormat:@"%lu", (unsigned long)priority] forHTTPHeaderField:@"apns-priority"];
+    
+    // apns-expiration
+    // apns-id
+    
+    NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        NSHTTPURLResponse *r = (NSHTTPURLResponse *)response;
+        
+        if (r.statusCode != 200 && data) {
+            NSError *error;
+            NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            
+            if (error) {return;}
+            
+            NSString *reason = dict[@"reason"];
+            
+            // Not implemented?
+            //      NSString *ID = r.allHeaderFields[@"apns-id"];
+            [self.delegate APNS:self didRecieveStatus:r.statusCode reason:reason forID:nil];
+        }
+    }];
+    [task resume];
+}
+
+- (void)pushPayload:(nonnull NSDictionary *)payload
+            toToken:(nonnull NSString *)token
+          withTopic:(nullable NSString *)topic
+           priority:(NSUInteger)priority
+          inSandbox:(BOOL)sandbox {
+    [self pushPayload:payload
+              toToken:token
+            withTopic:topic
+             priority:priority
+           collapseId:nil
+            inSandbox:sandbox];
 }
 
 #pragma mark - NSURLSessionDelegate


### PR DESCRIPTION
As mentioned in #51, I added support for apns-collapse-id.

For back compatibility, I added a new method containing `collapseId` as a parameter in `SBAPNS`, while keeping the original one. It should not be necessary. If you'd like, I could remove it with another commit. 
