### PR TITLE
Show an error when the connection to apns fails

### DIFF
--- a/Knuff/APNSViewController.m
+++ b/Knuff/APNSViewController.m
@@ -637,12 +637,21 @@
 #pragma mark - SBAPNSDelegate
 
 - (void)APNS:(SBAPNS *)APNS didRecieveStatus:(NSInteger)statusCode reason:(NSString *)reason forID:(NSString *)ID {
-  NSAlert *alert = [NSAlert new];
-  [alert addButtonWithTitle:@"OK"];
-  alert.messageText = @"Error delivering notification";
-  alert.informativeText = [NSString stringWithFormat:@"%ld: %@", (long)statusCode, reason];
-  
-  [alert beginSheetModalForWindow:self.document.windowForSheet completionHandler:nil];
+
+    [self showError:[NSString stringWithFormat:@"%ld: %@", (long)statusCode, reason]];
+}
+
+- (void)APNS:(nonnull SBAPNS *)APNS didFailWithError:(nonnull NSError *)error {
+    [self showError:[NSString stringWithFormat:@"Connection failed: %@", error]];
+}
+
+- (void)showError:(NSString *)errorMessage {
+    NSAlert *alert = [NSAlert new];
+    [alert addButtonWithTitle:@"OK"];
+    alert.messageText = @"Error delivering notification";
+    alert.informativeText = errorMessage;
+
+    [alert beginSheetModalForWindow:self.document.windowForSheet completionHandler:nil];
 }
 
 @end

--- a/Knuff/SBAPNS.h
+++ b/Knuff/SBAPNS.h
@@ -12,6 +12,7 @@
 
 @protocol SBAPNSDelegate <NSObject>
 - (void)APNS:(nonnull SBAPNS *)APNS didRecieveStatus:(NSInteger)statusCode reason:(nonnull NSString *)reason forID:(nullable NSString *)ID;
+- (void)APNS:(nonnull SBAPNS *)APNS didFailWithError:(nonnull NSError *)error;
 @end
 
 @interface SBAPNS : NSObject

--- a/Knuff/SBAPNS.m
+++ b/Knuff/SBAPNS.m
@@ -65,6 +65,13 @@
   NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
     NSHTTPURLResponse *r = (NSHTTPURLResponse *)response;
 
+    if (r == nil && error) {
+        if ([self.delegate respondsToSelector:@selector(APNS:didFailWithError:)]) {
+            [self.delegate APNS:self didFailWithError:error];
+        }
+        return;
+    }
+      
     if (r.statusCode != 200 && data) {
       NSError *error;
       NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];


### PR DESCRIPTION
Currently the `SBAPNSDelegate` was showing an error to the user only when the connection succeeds but Apple returns an error. 

If the connection itself fails (e.g. because of an invalid certificate) the Knuff was failing silently. 

With this PR, the user will get an error dialog as well in this case.

