### PR TITLE
APNS push type (iOS 13, watchOS 6)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendor/Fragaria"]
 	path = Vendor/Fragaria
-	url = git@github.com:shysaur/Fragaria.git
+	url = https://github.com/shysaur/Fragaria.git

--- a/Knuff.xcodeproj/project.pbxproj
+++ b/Knuff.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		E4F537C71E02DBBCEE7E4B79 /* libPods-Knuff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4664BA2573F4204E05EDA01A /* libPods-Knuff.a */; };
 		F402B938202B9D6200E3F6A4 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F402B936202B9D6200E3F6A4 /* Crashlytics.framework */; };
 		F402B939202B9D6200E3F6A4 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F402B937202B9D6200E3F6A4 /* Fabric.framework */; };
 		F4069AF01AB47A60008E79D8 /* APNSItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F4069AEF1AB47A60008E79D8 /* APNSItem.m */; };
@@ -31,6 +30,7 @@
 		F46BF9031C148A8F003ED597 /* Fragaria.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F46BF9001C148A60003ED597 /* Fragaria.framework */; };
 		F46BF9041C148A8F003ED597 /* Fragaria.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F46BF9001C148A60003ED597 /* Fragaria.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F4D364BF1E466E5E00D8EBCC /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = F4D364BE1E466E5D00D8EBCC /* dsa_pub.pem */; };
+		FECFE5744DC13647DFE19EEC /* Pods_Knuff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EF9C39E93DC21EF51D7E054 /* Pods_Knuff.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,9 +108,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		4664BA2573F4204E05EDA01A /* libPods-Knuff.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Knuff.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9770263A3A3A9B43628811DF /* Pods-Knuff.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Knuff.release.xcconfig"; path = "Pods/Target Support Files/Pods-Knuff/Pods-Knuff.release.xcconfig"; sourceTree = "<group>"; };
-		DC2EADEF87C1C11E371F946F /* Pods-Knuff.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Knuff.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Knuff/Pods-Knuff.debug.xcconfig"; sourceTree = "<group>"; };
+		1EF9C39E93DC21EF51D7E054 /* Pods_Knuff.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Knuff.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		78DAA706A91FFEBE8B3339DE /* Pods-Knuff.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Knuff.debug.xcconfig"; path = "Target Support Files/Pods-Knuff/Pods-Knuff.debug.xcconfig"; sourceTree = "<group>"; };
+		889BA9E14747250BFE8AFC25 /* Pods-Knuff.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Knuff.release.xcconfig"; path = "Target Support Files/Pods-Knuff/Pods-Knuff.release.xcconfig"; sourceTree = "<group>"; };
 		F402B936202B9D6200E3F6A4 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = SOURCE_ROOT; };
 		F402B937202B9D6200E3F6A4 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = SOURCE_ROOT; };
 		F4069AEE1AB47A60008E79D8 /* APNSItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APNSItem.h; sourceTree = "<group>"; };
@@ -158,28 +158,21 @@
 				F402B939202B9D6200E3F6A4 /* Fabric.framework in Frameworks */,
 				F46BF9031C148A8F003ED597 /* Fragaria.framework in Frameworks */,
 				F402B938202B9D6200E3F6A4 /* Crashlytics.framework in Frameworks */,
-				E4F537C71E02DBBCEE7E4B79 /* libPods-Knuff.a in Frameworks */,
+				FECFE5744DC13647DFE19EEC /* Pods_Knuff.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		26BF8A2DD3191BB117FB8A6C /* Frameworks */ = {
+		621B1DBD16401B73E5F7C98D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4664BA2573F4204E05EDA01A /* libPods-Knuff.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		7F1C710D1E10C5ABBF288CCC /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				DC2EADEF87C1C11E371F946F /* Pods-Knuff.debug.xcconfig */,
-				9770263A3A3A9B43628811DF /* Pods-Knuff.release.xcconfig */,
+				78DAA706A91FFEBE8B3339DE /* Pods-Knuff.debug.xcconfig */,
+				889BA9E14747250BFE8AFC25 /* Pods-Knuff.release.xcconfig */,
 			);
 			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		F45929F41AB475D000041A6C = {
@@ -189,8 +182,8 @@
 				F45929FF1AB475D000041A6C /* Knuff */,
 				F4592A191AB475D000041A6C /* KnuffTests */,
 				F45929FE1AB475D000041A6C /* Products */,
-				7F1C710D1E10C5ABBF288CCC /* Pods */,
-				26BF8A2DD3191BB117FB8A6C /* Frameworks */,
+				621B1DBD16401B73E5F7C98D /* Pods */,
+				FCC415225C9ABC74EE7C9202 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -296,6 +289,14 @@
 			path = Vendor;
 			sourceTree = "<group>";
 		};
+		FCC415225C9ABC74EE7C9202 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1EF9C39E93DC21EF51D7E054 /* Pods_Knuff.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -303,13 +304,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4592A201AB475D000041A6C /* Build configuration list for PBXNativeTarget "Knuff" */;
 			buildPhases = (
-				7D395788BCACB60A7AF824F5 /* [CP] Check Pods Manifest.lock */,
+				77DDC29A1CBBC82B605E6B29 /* [CP] Check Pods Manifest.lock */,
 				F45929F91AB475D000041A6C /* Sources */,
 				F45929FA1AB475D000041A6C /* Frameworks */,
 				F45929FB1AB475D000041A6C /* Resources */,
 				F43C1EEA1AC329C9001D9501 /* Embed Frameworks */,
-				05A1DB78D60784A3D04A0F7D /* [CP] Copy Pods Resources */,
 				F402B935202B9D3200E3F6A4 /* Fabric */,
+				2C20D078B63C57C455A211E0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -327,7 +328,7 @@
 		F45929F51AB475D000041A6C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1110;
 				ORGANIZATIONNAME = Bowtie;
 				TargetAttributes = {
 					F45929FC1AB475D000041A6C = {
@@ -348,10 +349,9 @@
 			};
 			buildConfigurationList = F45929F81AB475D000041A6C /* Build configuration list for PBXProject "Knuff" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -439,34 +439,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		05A1DB78D60784A3D04A0F7D /* [CP] Copy Pods Resources */ = {
+		2C20D078B63C57C455A211E0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Knuff/Pods-Knuff-resources.sh",
-				"${PODS_ROOT}/CupertinoJWT/install_common_crypto.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Knuff/Pods-Knuff-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CupertinoJWT/CupertinoJWT.framework",
+				"${BUILT_PRODUCTS_DIR}/KVOController/KVOController.framework",
+				"${BUILT_PRODUCTS_DIR}/Mantle/Mantle.framework",
+				"${BUILT_PRODUCTS_DIR}/pop/pop.framework",
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/install_common_crypto.sh",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CupertinoJWT.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KVOController.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mantle.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/pop.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Knuff/Pods-Knuff-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Knuff/Pods-Knuff-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7D395788BCACB60A7AF824F5 /* [CP] Check Pods Manifest.lock */ = {
+		77DDC29A1CBBC82B605E6B29 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			inputFileListPaths = (
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Knuff-checkManifestLockResult.txt",
 			);
@@ -637,7 +647,7 @@
 		};
 		F4592A211AB475D000041A6C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC2EADEF87C1C11E371F946F /* Pods-Knuff.debug.xcconfig */;
+			baseConfigurationReference = 78DAA706A91FFEBE8B3339DE /* Pods-Knuff.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
@@ -645,6 +655,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = N2ML8MSSRH;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -654,15 +665,13 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.madebybowtie.Knuff-OSX";
 				PRODUCT_NAME = Knuff;
-				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		F4592A221AB475D000041A6C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9770263A3A3A9B43628811DF /* Pods-Knuff.release.xcconfig */;
+			baseConfigurationReference = 889BA9E14747250BFE8AFC25 /* Pods-Knuff.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
@@ -670,6 +679,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = N2ML8MSSRH;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -679,9 +689,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.madebybowtie.Knuff-OSX";
 				PRODUCT_NAME = Knuff;
-				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Knuff/APNSItem.h
+++ b/Knuff/APNSItem.h
@@ -8,6 +8,8 @@
 
 #import "MTLModel.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, APNSItemMode) {
   APNSItemModeCustom,
   APNSItemModeKnuff
@@ -18,12 +20,83 @@ typedef NS_ENUM(NSUInteger, APNSItemPriority) {
   APNSItemPriorityImmediately = 10
 };
 
+typedef NS_ENUM(NSUInteger, APNSItemPushType) {
+
+  /**
+   Use the alert push type for notifications that trigger a user interaction—for example, an alert, badge, or sound. If you set this push type, the apns-topic header field must use your app’s bundle ID as the topic. For more information, see Generating a Remote Notification.
+   The alert push type is required on watchOS 6 and later. It is recommended on macOS, iOS, tvOS, and iPadOS.
+   */
+  APNSItemPushTypeAlert,
+
+  /**
+   Use the background push type for notifications that deliver content in the background, and don’t trigger any user interactions. If you set this push type, the apns-topic header field must use your app’s bundle ID as the topic. For more information, see Pushing Background Updates to Your App.
+   The background push type is required on watchOS 6 and later. It is recommended on macOS, iOS, tvOS, and iPadOS.
+   */
+  APNSItemPushTypeBackground,
+
+  /**
+   Use the voip push type for notifications that provide information about an incoming Voice-over-IP (VoIP) call. For more information, see Responding to VoIP Notifications from PushKit.
+   If you set this push type, the apns-topic header field must use your app’s bundle ID with .voip appended to the end. If you’re using certificate-based authentication, you must also register the certificate for VoIP services. The topic is then part of the 1.2.840.113635.100.6.3.4 or 1.2.840.113635.100.6.3.6 extension.
+   The voip push type is not available on watchOS. It is recommended on macOS, iOS, tvOS, and iPadOS.
+   */
+  APNSItemPushTypeVoip,
+
+  /**
+   Use the complication push type for notifications that contain update information for a watchOS app’s complications. For more information, see Updating Your Timeline.
+   If you set this push type, the apns-topic header field must use your app’s bundle ID with .complication appended to the end. If you’re using certificate-based authentication, you must also register the certificate for WatchKit services. The topic is then part of the 1.2.840.113635.100.6.3.6 extension.
+   The complication push type is recommended for watchOS and iOS. It is not available on macOS, tvOS, and iPadOS.
+   */
+  APNSItemPushTypeComplication,
+
+  /**
+   Use the fileprovider push type to signal changes to a File Provider extension. If you set this push type, the apns-topic header field must use your app’s bundle ID with .pushkit.fileprovider appended to the end. For more information, see Using Push Notifications to Signal Changes.
+   The fileprovider push type is not available on watchOS. It is recommended on macOS, iOS, tvOS, and iPadOS.
+   */
+  APNSItemPushTypeFileProvider,
+
+  /**
+   Use the mdm push type for notifications that tell managed devices to contact the MDM server. If you set this push type, you must use the topic from the UID attribute in the subject of your MDM push certificate. For more information, see Device Management.
+   The mdm push type is not available on watchOS. It is recommended on macOS, iOS, tvOS, and iPadOS.
+   */
+  APNSItemPushTypeMDM
+};
+
+/**
+ Default APNSItemPushType.
+ */
+APNSItemPushType APNSItemPushTypeDefault(void);
+
+/**
+ Retrieve the valid string value for the HTTP header.
+ */
+NSString *APNSItemPushTypeToStr(APNSItemPushType pushType);
+
+/**
+ Retrieve APNSItemPushType from string value.
+ */
+APNSItemPushType APNSItemPushTypeFromStr(NSString *pushTypeStr);
+
+/**
+ Retrieve all APNSItemPushType values.
+ */
+NSArray<NSString *> *APNSItemPushTypesAll(void);
+
 @interface APNSItem : MTLModel
+
 @property (nonatomic, copy) NSString *token;
 @property (nonatomic, copy) NSString *payload;
 @property (nonatomic) APNSItemMode mode;
 @property (nonatomic, copy) NSString *certificateDescription;
 @property (nonatomic) APNSItemPriority priority;
+
+/**
+ Required for watchOS 6 and later; recommended for macOS, iOS, tvOS, and iPadOS) The value of this header must accurately reflect the contents of your notification’s payload. If there is a mismatch, or if the header is missing on required systems, APNs may return an error, delay the delivery of the notification, or drop it altogether.
+ */
+@property (nonatomic) APNSItemPushType pushType NS_AVAILABLE(10_15, 13_0);
+
 @property (nonatomic) NSString *collapseID;
 @property (nonatomic) BOOL sandbox; // Only used when an identity includes both development and production
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Knuff/APNSItem.m
+++ b/Knuff/APNSItem.m
@@ -10,3 +10,59 @@
 
 @implementation APNSItem
 @end
+
+APNSItemPushType APNSItemPushTypeDefault(void) {
+  return APNSItemPushTypeAlert;
+}
+
+NSString *APNSItemPushTypeToStr(APNSItemPushType pushType) {
+  switch (pushType) {
+    case APNSItemPushTypeAlert:
+      return @"alert"; //0
+    case APNSItemPushTypeBackground:
+      return @"background"; //1
+    case APNSItemPushTypeVoip:
+      return @"voip"; //2
+    case APNSItemPushTypeComplication:
+      return @"complication"; //3
+    case APNSItemPushTypeFileProvider:
+      return @"fileprovider"; //4
+    case APNSItemPushTypeMDM:
+      return @"mdm"; //5
+  }
+}
+
+APNSItemPushType APNSItemPushTypeFromStr(NSString *pushTypeStr) {
+  if ([pushTypeStr isEqualToString:APNSItemPushTypeToStr(APNSItemPushTypeAlert)]) {
+    return APNSItemPushTypeAlert;
+  }
+  else if ([pushTypeStr isEqualToString:APNSItemPushTypeToStr(APNSItemPushTypeBackground)]) {
+    return APNSItemPushTypeBackground;
+  }
+  else if ([pushTypeStr isEqualToString:APNSItemPushTypeToStr(APNSItemPushTypeVoip)]) {
+    return APNSItemPushTypeVoip;
+  }
+  else if ([pushTypeStr isEqualToString:APNSItemPushTypeToStr(APNSItemPushTypeComplication)]) {
+    return APNSItemPushTypeComplication;
+  }
+  else if ([pushTypeStr isEqualToString:APNSItemPushTypeToStr(APNSItemPushTypeFileProvider)]) {
+    return APNSItemPushTypeFileProvider;
+  }
+  else if ([pushTypeStr isEqualToString:APNSItemPushTypeToStr(APNSItemPushTypeMDM)]) {
+    return APNSItemPushTypeMDM;
+  }
+  else {
+    return APNSItemPushTypeDefault();
+  }
+}
+
+NSArray<NSString *> *APNSItemPushTypesAll(void) {
+  return @[
+    APNSItemPushTypeToStr(APNSItemPushTypeAlert),
+    APNSItemPushTypeToStr(APNSItemPushTypeBackground),
+    APNSItemPushTypeToStr(APNSItemPushTypeVoip),
+    APNSItemPushTypeToStr(APNSItemPushTypeComplication),
+    APNSItemPushTypeToStr(APNSItemPushTypeFileProvider),
+    APNSItemPushTypeToStr(APNSItemPushTypeMDM),
+  ];
+}

--- a/Knuff/APNSViewController.m
+++ b/Knuff/APNSViewController.m
@@ -58,6 +58,7 @@
 @property (weak) IBOutlet NSSegmentedControl *prioritySegmentedControl; // Only 5 and 10
 
 @property (weak) IBOutlet NSPopUpButton *topicsPopUpButton;
+@property (weak) IBOutlet NSPopUpButton *payloadTypePopUpButton;
 
 @property (nonatomic) BOOL showSandbox; // current state of the UI
 @property (weak) IBOutlet NSSegmentedControl *sandboxSegmentedControl;
@@ -95,6 +96,9 @@
     
   [self.topicsPopUpButton removeAllItems];
   self.topicsPopUpButton.enabled = NO;
+
+  [self.payloadTypePopUpButton removeAllItems];
+  [self.payloadTypePopUpButton addItemsWithTitles:APNSItemPushTypesAll()];
   
   [[MGSUserDefaultsController sharedController] addFragariaToManagedSet:self.fragariaView];
 }

--- a/Knuff/APNSViewController.m
+++ b/Knuff/APNSViewController.m
@@ -24,7 +24,7 @@
 
 #import "FBKVOController.h"
 
-#import "pop.h"
+#import <pop/POP.h>
 #import <Fragaria/Fragaria.h>
 
 @interface APNSViewController () <MGSFragariaTextViewDelegate, MGSDragOperationDelegate, APNSDevicesViewControllerDelegate, NSPopoverDelegate, NSTextViewDelegate, SBAPNSDelegate>
@@ -432,7 +432,7 @@
       POPSpringAnimation *animation = [POPSpringAnimation animationWithPropertyNamed:kPOPViewAlphaValue];
       
       [animation setCompletionBlock:^(POPAnimation *ani, BOOL fin) {
-        if (!_showSandbox) {
+        if (!self->_showSandbox) {
           self.sandboxSegmentedControl.hidden = YES;
         }
       }];

--- a/Knuff/APNSViewController.m
+++ b/Knuff/APNSViewController.m
@@ -206,12 +206,13 @@
     } else if (type == APNSSecIdentityTypeUniversal) {
       sandbox = [self document].sandbox;
     }
-    
+
     [self.APNS pushPayload:self.payload
                    toToken:[self preparedToken]
                  withTopic:self.topicsPopUpButton.selectedItem.title
                   priority:self.document.priority
                 collapseID:self.document.collapseID
+               payloadType:APNSItemPushTypeFromStr(self.payloadTypePopUpButton.selectedItem.title)
                  inSandbox:sandbox];
   } else if ([self document].mode == APNSItemModeKnuff) {
     // Grab cert
@@ -241,6 +242,7 @@
                  withTopic:@"com.madebybowtie.Knuff-iOS"
                   priority:self.document.priority
                 collapseID:self.document.collapseID
+               payloadType:APNSItemPushTypeFromStr(self.payloadTypePopUpButton.selectedItem.title)
                  inSandbox:NO];
   } else {
     //    NSAlert *alert = [NSAlert new];

--- a/Knuff/Base.lproj/Main.storyboard
+++ b/Knuff/Base.lproj/Main.storyboard
@@ -742,10 +742,10 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="mrI-Z0-do9">
-                                        <rect key="frame" x="64" y="39" width="374" height="197"/>
+                                        <rect key="frame" x="64" y="39" width="374" height="163"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <view key="contentView" id="Lwi-gz-XGt" customClass="MGSFragariaView">
-                                            <rect key="frame" x="1" y="1" width="372" height="195"/>
+                                            <rect key="frame" x="1" y="1" width="372" height="161"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         </view>
                                         <color key="borderColor" white="0.0" alpha="0.20000000000000001" colorSpace="calibratedWhite"/>
@@ -827,7 +827,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ji4-oK-Cm1">
-                                        <rect key="frame" x="214" y="255" width="218" height="22"/>
+                                        <rect key="frame" x="214" y="256" width="218" height="22"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="7SA-gf-qsz">
                                             <font key="font" metaFont="system"/>
@@ -839,7 +839,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UNw-8x-tcA">
-                                        <rect key="frame" x="-2" y="219" width="58" height="17"/>
+                                        <rect key="frame" x="-1" y="185" width="58" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Payload:" id="0qN-Z1-PD3">
                                             <font key="font" metaFont="system"/>
@@ -870,6 +870,30 @@
                                             <action selector="changePriority:" target="5gI-5U-AMq" id="mpf-bT-TSe"/>
                                         </connections>
                                     </segmentedControl>
+                                    <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fvt-6a-dsp" userLabel="Type: PopUp Button">
+                                        <rect key="frame" x="212" y="224" width="223" height="26"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                        <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="pm2-Fi-Ud5" id="ceZ-zF-4mv">
+                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                            <menu key="menu" id="aEp-HZ-hxw">
+                                                <items>
+                                                    <menuItem title="Item 1" state="on" id="pm2-Fi-Ud5"/>
+                                                    <menuItem title="Item 2" id="HIC-dN-pRy"/>
+                                                    <menuItem title="Item 3" id="DPQ-Mi-4g5"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                    </popUpButton>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q8Y-Bi-MDi">
+                                        <rect key="frame" x="117" y="229" width="89" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Payload Type:" id="XCt-oa-qFs">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                 </subviews>
                             </customView>
                             <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oPK-43-5bT">
@@ -895,6 +919,7 @@
                         <outlet property="identityView" destination="qIH-Kw-NVg" id="rFM-Gk-hIi"/>
                         <outlet property="identityWrapperView" destination="mLb-IA-Hew" id="zAz-9r-tz0"/>
                         <outlet property="modeSegmentedControl" destination="oPK-43-5bT" id="LTZ-dm-km3"/>
+                        <outlet property="payloadTypePopUpButton" destination="fvt-6a-dsp" id="fwH-aL-LnS"/>
                         <outlet property="payloadView" destination="Xr8-yk-ahB" id="XrG-c3-yMs"/>
                         <outlet property="prioritySegmentedControl" destination="8NS-MQ-LIZ" id="cPu-YG-995"/>
                         <outlet property="sandboxSegmentedControl" destination="QQg-T8-GTZ" id="1Mj-Oo-Fid"/>

--- a/Knuff/Base.lproj/Main.storyboard
+++ b/Knuff/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -655,7 +654,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="Document Window Controller" id="jGA-0Y-lOj" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="Ckk-yw-fiv">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="Ckk-yw-fiv">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <rect key="contentRect" x="573" y="417" width="462" height="301"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
@@ -676,15 +675,15 @@
         <scene sceneID="hIz-AP-VOD">
             <objects>
                 <viewController id="5gI-5U-AMq" customClass="APNSViewController" sceneMemberID="viewController">
-                    <view key="view" misplaced="YES" id="ERx-hH-rdd">
+                    <view key="view" id="ERx-hH-rdd">
                         <rect key="frame" x="0.0" y="0.0" width="478" height="450"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <customView id="mLb-IA-Hew">
+                            <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mLb-IA-Hew">
                                 <rect key="frame" x="20" y="374" width="438" height="21"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <subviews>
-                                    <segmentedControl verticalHuggingPriority="750" id="QQg-T8-GTZ">
+                                    <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QQg-T8-GTZ">
                                         <rect key="frame" x="296" y="1" width="142" height="20"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                         <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="selectOne" id="WyC-zr-iv2">
@@ -698,11 +697,11 @@
                                             <action selector="changeSandbox:" target="5gI-5U-AMq" id="o9A-lN-WmA"/>
                                         </connections>
                                     </segmentedControl>
-                                    <customView id="qIH-Kw-NVg">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qIH-Kw-NVg">
                                         <rect key="frame" x="0.0" y="0.0" width="289" height="21"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="2mf-de-hcm">
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2mf-de-hcm">
                                                 <rect key="frame" x="2" y="2" width="54" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Identity:" id="bwM-c4-7IO">
@@ -711,7 +710,7 @@
                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="CCt-Rq-sL5">
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CCt-Rq-sL5">
                                                 <rect key="frame" x="60" y="2" width="138" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Label" id="cru-br-n6r">
@@ -723,7 +722,7 @@
                                                     <binding destination="5gI-5U-AMq" name="value" keyPath="self.identityName" id="WFQ-EP-zQD"/>
                                                 </connections>
                                             </textField>
-                                            <button verticalHuggingPriority="750" id="0BT-CV-8ej">
+                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0BT-CV-8ej">
                                                 <rect key="frame" x="206" y="-7" width="88" height="32"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                 <buttonCell key="cell" type="push" title="Choose..." bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ojx-OQ-85A">
@@ -738,11 +737,11 @@
                                     </customView>
                                 </subviews>
                             </customView>
-                            <customView id="Xr8-yk-ahB">
+                            <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xr8-yk-ahB">
                                 <rect key="frame" x="20" y="20" width="438" height="346"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <box autoresizesSubviews="NO" misplaced="YES" boxType="custom" borderType="line" title="Box" titlePosition="noTitle" id="mrI-Z0-do9">
+                                    <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="mrI-Z0-do9">
                                         <rect key="frame" x="64" y="39" width="374" height="197"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <view key="contentView" id="Lwi-gz-XGt" customClass="MGSFragariaView">
@@ -751,7 +750,7 @@
                                         </view>
                                         <color key="borderColor" white="0.0" alpha="0.20000000000000001" colorSpace="calibratedWhite"/>
                                     </box>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="UQG-Dc-iPa">
+                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UQG-Dc-iPa">
                                         <rect key="frame" x="11" y="322" width="45" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Token:" id="8Kf-Yw-LOk">
@@ -760,19 +759,19 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField verticalHuggingPriority="750" id="bbC-aP-Fg6">
+                                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bbC-aP-Fg6">
                                         <rect key="frame" x="64" y="320" width="309" height="22"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX" drawsBackground="YES" id="EmN-JJ-Jlu">
                                             <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                         <connections>
                                             <outlet property="delegate" destination="5gI-5U-AMq" id="rUx-D5-JDH"/>
                                         </connections>
                                     </textField>
-                                    <button verticalHuggingPriority="750" id="pqI-ZA-wIg">
+                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pqI-ZA-wIg">
                                         <rect key="frame" x="373" y="-7" width="71" height="32"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                         <buttonCell key="cell" type="push" title="Push" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xy2-zc-sn4">
@@ -783,7 +782,7 @@
                                             <action selector="push:" target="5gI-5U-AMq" id="Xg6-g5-aJV"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" id="vRS-dS-ngr">
+                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRS-dS-ngr">
                                         <rect key="frame" x="381" y="322" width="57" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="inline" title="Devices" bezelStyle="inline" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RDO-Ub-kHM">
@@ -794,7 +793,7 @@
                                             <action selector="presentDevices:" target="5gI-5U-AMq" id="2vt-PD-ueD"/>
                                         </connections>
                                     </button>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DIk-TA-wEH">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DIk-TA-wEH">
                                         <rect key="frame" x="4" y="287" width="52" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Priority:" id="j57-Z7-jPS">
@@ -803,12 +802,12 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <popUpButton verticalHuggingPriority="750" misplaced="YES" id="yao-9o-3kP" userLabel="Topic: PopUp Button">
+                                    <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yao-9o-3kP" userLabel="Topic: PopUp Button">
                                         <rect key="frame" x="212" y="282" width="223" height="26"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="24o-ik-Lc7" id="dak-1Q-4N5">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="menu"/>
+                                            <font key="font" metaFont="system"/>
                                             <menu key="menu" id="ShR-Ag-ueQ">
                                                 <items>
                                                     <menuItem title="Item 1" state="on" id="24o-ik-Lc7"/>
@@ -818,7 +817,7 @@
                                             </menu>
                                         </popUpButtonCell>
                                     </popUpButton>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" id="1Dt-1J-uuM">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Dt-1J-uuM">
                                         <rect key="frame" x="165" y="287" width="41" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Topic:" id="389-pq-KDY">
@@ -827,19 +826,19 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField verticalHuggingPriority="750" misplaced="YES" id="Ji4-oK-Cm1">
+                                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ji4-oK-Cm1">
                                         <rect key="frame" x="214" y="255" width="218" height="22"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="7SA-gf-qsz">
                                             <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                         <connections>
                                             <outlet property="delegate" destination="5gI-5U-AMq" id="Ew3-BO-Ae5"/>
                                         </connections>
                                     </textField>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" id="UNw-8x-tcA">
+                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UNw-8x-tcA">
                                         <rect key="frame" x="-2" y="219" width="58" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Payload:" id="0qN-Z1-PD3">
@@ -848,7 +847,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" id="Xia-UC-heD">
+                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xia-UC-heD">
                                         <rect key="frame" x="97" y="258" width="109" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Collapse ID:" id="JP3-Pw-ekx">
@@ -857,7 +856,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <segmentedControl verticalHuggingPriority="750" misplaced="YES" id="8NS-MQ-LIZ">
+                                    <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8NS-MQ-LIZ">
                                         <rect key="frame" x="62" y="283" width="77" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="bdX-yl-Dpn">
@@ -873,7 +872,7 @@
                                     </segmentedControl>
                                 </subviews>
                             </customView>
-                            <segmentedControl verticalHuggingPriority="750" springLoaded="YES" id="oPK-43-5bT">
+                            <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oPK-43-5bT">
                                 <rect key="frame" x="160" y="407" width="160" height="24"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="4UY-6g-EgJ">
@@ -916,23 +915,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="271" height="161"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <scrollView autohidesScrollers="YES" horizontalLineScroll="62" horizontalPageScroll="10" verticalLineScroll="62" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="Pxa-sM-V0W">
+                            <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="62" horizontalPageScroll="10" verticalLineScroll="62" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pxa-sM-V0W">
                                 <rect key="frame" x="0.0" y="0.0" width="271" height="161"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <clipView key="contentView" id="lee-qQ-3Ry">
+                                <clipView key="contentView" ambiguous="YES" id="lee-qQ-3Ry">
                                     <rect key="frame" x="1" y="1" width="269" height="159"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="60" viewBased="YES" id="hzB-zg-tZ1">
+                                        <tableView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="60" viewBased="YES" id="hzB-zg-tZ1">
                                             <rect key="frame" x="0.0" y="0.0" width="269" height="159"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="" width="266.19392734220924" minWidth="40" maxWidth="1000" id="pIm-ng-PDy">
+                                                <tableColumn width="266.19392734220924" minWidth="40" maxWidth="1000" id="pIm-ng-PDy">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <font key="font" metaFont="message" size="11"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -947,7 +946,7 @@
                                                             <rect key="frame" x="1" y="1" width="266" height="60"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="PvO-PD-lG7">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PvO-PD-lG7">
                                                                     <rect key="frame" x="1" y="33" width="264" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Simon's iPhone 7" id="gF5-0S-bcN">
@@ -956,7 +955,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Tbf-pH-qQN">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tbf-pH-qQN">
                                                                     <rect key="frame" x="1" y="8" width="264" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="FE66489F 304DC75B 8D6E8200 DFF8A456 E8DAEACEC428B427E9518741C92C6660" id="nqS-bB-CJI">
@@ -982,11 +981,11 @@
                                         </tableView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="1vK-kJ-mEz">
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="1vK-kJ-mEz">
                                     <rect key="frame" x="1" y="144" width="269" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.99999999999979483" horizontal="NO" id="D3K-FU-ose">
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.99999999999979483" horizontal="NO" id="D3K-FU-ose">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>

--- a/Knuff/SBAPNS.h
+++ b/Knuff/SBAPNS.h
@@ -10,19 +10,24 @@
 
 @class SBAPNS;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol SBAPNSDelegate <NSObject>
-- (void)APNS:(nonnull SBAPNS *)APNS didRecieveStatus:(NSInteger)statusCode reason:(nonnull NSString *)reason forID:(nullable NSString *)ID;
-- (void)APNS:(nonnull SBAPNS *)APNS didFailWithError:(nonnull NSError *)error;
+- (void)APNS:(SBAPNS *)APNS didRecieveStatus:(NSInteger)statusCode reason:(NSString *)reason forID:(nullable NSString *)ID;
+- (void)APNS:(SBAPNS *)APNS didFailWithError:(NSError *)error;
 @end
 
 @interface SBAPNS : NSObject
 @property (nonatomic, strong, nullable) __attribute__((NSObject)) SecIdentityRef identity;
 @property (nonatomic, weak, nullable) id<SBAPNSDelegate> delegate;
 
-- (void)pushPayload:(nonnull NSDictionary *)payload
-            toToken:(nonnull NSString *)token
+- (void)pushPayload:(NSDictionary *)payload
+            toToken:(NSString *)token
           withTopic:(nullable NSString *)topic
            priority:(NSUInteger)priority
          collapseID:(nullable NSString *)collapseID
+        payloadType:(NSUInteger)payloadType
           inSandbox:(BOOL)sandbox;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Knuff/SBAPNS.m
+++ b/Knuff/SBAPNS.m
@@ -9,6 +9,7 @@
 #import "SBAPNS.h"
 #import <Security/Security.h>
 #import "APNSSecIdentityType.h"
+#import "APNSItem.h"
 
 @interface SBAPNS () <NSURLSessionDelegate>
 @property (nonatomic, strong) NSURLSession *session;
@@ -41,14 +42,14 @@
 
 #pragma mark - Public
 
-- (void)pushPayload:(nonnull NSDictionary *)payload
-            toToken:(nonnull NSString *)token
+- (void)pushPayload:(NSDictionary *)payload
+            toToken:(NSString *)token
           withTopic:(nullable NSString *)topic
            priority:(NSUInteger)priority
          collapseID:(NSString *)collapseID
+        payloadType:(NSUInteger)payloadType
           inSandbox:(BOOL)sandbox {
-  
-  
+
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://api%@.push.apple.com/3/device/%@", sandbox?@".development":@"", token]]];
   request.HTTPMethod = @"POST";
   
@@ -61,8 +62,10 @@
   if (collapseID.length > 0) {
     [request addValue:collapseID forHTTPHeaderField:@"apns-collapse-id"];
   }
-  
+
   [request addValue:[NSString stringWithFormat:@"%lu", (unsigned long)priority] forHTTPHeaderField:@"apns-priority"];
+
+  [request addValue:APNSItemPushTypeToStr(payloadType) forHTTPHeaderField:@"apns-push-type"];
   
   // apns-expiration
   // apns-id

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,9 @@
 platform :macos, '10.12'
+use_frameworks!
 
 target "Knuff" do
-	pod 'Mantle'
-	pod 'KVOController'
-	pod 'pop'
+  pod 'Mantle'
+  pod 'KVOController'
+  pod 'pop'
   pod 'CupertinoJWT'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - pop
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - CupertinoJWT
     - KVOController
     - Mantle
@@ -27,4 +27,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 730f48b4919d2b68e5b0fccc1c6ca54621dec4db
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - Mantle (2.1.0):
     - Mantle/extobjc (= 2.1.0)
   - Mantle/extobjc (2.1.0)
-  - pop (1.0.10)
+  - pop (1.0.12)
 
 DEPENDENCIES:
   - CupertinoJWT
@@ -23,8 +23,8 @@ SPEC CHECKSUMS:
   CupertinoJWT: f712fdc2cc422aac8daa301ad1dce05ea9f6b6d6
   KVOController: d72ace34afea42468329623b3379ab3cd1d286b6
   Mantle: 2fa750afa478cd625a94230fbf1c13462f29395b
-  pop: 82ca6b068ce9278fd350fd9dd09482a0ce9492e6
+  pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
 
-PODFILE CHECKSUM: 730f48b4919d2b68e5b0fccc1c6ca54621dec4db
+PODFILE CHECKSUM: d375209187574efe6f924c0b7f518dd999133bb3
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Related with #85.

### Changes:
- Support for [APNS push type](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns).

apns-push-type | (Required for watchOS 6 and later; recommended for macOS, iOS, tvOS, and iPadOS) The value of this header must accurately reflect the contents of your notification’s payload. If there is a mismatch, or if the header is missing on required systems, APNs may return an error, delay the delivery of the notification, or drop it altogether.
-- | --

- Update project to Xcode 11.

#### Screenshot
![Screenshot 2019-10-25 at 16 51 07](https://user-images.githubusercontent.com/3541185/67585590-c4eb3b80-f747-11e9-9b9b-98217cae512a.png)


